### PR TITLE
Release Unreleased version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 file system monitor plugin for [heimdalljs](https://github.com/heimdalljs/heimdalljs-lib)
 
+> [!Note]
+> This has been forked from the archived repo https://github.com/heimdalljs/heimdall-fs-monitor to fix an issue with Node 24
+
 
 ## Installation
 


### PR DESCRIPTION
It turns out that `v1.1.1` was already on npm so https://github.com/ember-cli/heimdall-fs-monitor/releases/tag/v1.1.1-heimdalljs-fs-monitor didn't actually go out 🙈 

This PR is just here to allow us to bump the version and get a release out 👍 